### PR TITLE
fix: ignore unknown JSON fields when parsing evaluations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "com.klee.sapio"
         minSdk 21
         targetSdk 35
-        versionCode 89
-        versionName "2.5.0"
+        versionCode 90
+        versionName "2.5.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/data/src/main/java/com/klee/sapio/data/api/RetrofitClient.kt
+++ b/data/src/main/java/com/klee/sapio/data/api/RetrofitClient.kt
@@ -5,6 +5,8 @@ import android.graphics.Bitmap
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.util.Log
 import androidx.core.graphics.drawable.toBitmap
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.klee.sapio.data.dto.Evaluation
 import com.klee.sapio.data.dto.IconAnswer
 import com.klee.sapio.data.dto.StrapiAnswer
@@ -107,10 +109,13 @@ open class EvaluationService @Inject constructor(
             .cache(Cache(context.cacheDir, CACHE_MAX_SIZE))
             .build()
 
+        val objectMapper = ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
         retrofit = Retrofit.Builder()
             .client(okHttpClient)
             .baseUrl("$BASE_URL/api/")
-            .addConverterFactory(JacksonConverterFactory.create())
+            .addConverterFactory(JacksonConverterFactory.create(objectMapper))
             .build()
 
         evaluationsApi = retrofit.create(EvaluationApi::class.java)

--- a/data/src/main/java/com/klee/sapio/data/dto/Evaluation.kt
+++ b/data/src/main/java/com/klee/sapio/data/dto/Evaluation.kt
@@ -1,8 +1,10 @@
 package com.klee.sapio.data.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.Date
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Evaluation(
     @JsonProperty("name") val name: String,
     @JsonProperty("packageName") val packageName: String,

--- a/data/src/main/java/com/klee/sapio/data/dto/StrapiDtos.kt
+++ b/data/src/main/java/com/klee/sapio/data/dto/StrapiDtos.kt
@@ -1,7 +1,9 @@
 package com.klee.sapio.data.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class StrapiAnswer(
     @JsonProperty("data") val data: ArrayList<StrapiElement>,
     @JsonProperty("meta") val meta: StrapiMeta


### PR DESCRIPTION
## Problem
After an additive change to the Strapi server (a new feature attribute on `sapio-application`), the shipped app could no longer load any evaluations. The list response is deserialized in one shot with a default Jackson `ObjectMapper`, whose `FAIL_ON_UNKNOWN_PROPERTIES` defaults to `true`, so a single unrecognized field failed the entire response.

## Fix
- Configure the Retrofit converter's `ObjectMapper` with `FAIL_ON_UNKNOWN_PROPERTIES = false`.
- Annotate the `Evaluation` and `StrapiAnswer` DTOs with `@JsonIgnoreProperties(ignoreUnknown = true)` as defense-in-depth.

This makes the client tolerant of additive server-side schema changes, so they no longer break deserialization on already-shipped clients. Verified working against the live server with a debug build.

Also bumps the app version to 2.5.1 (versionCode 90).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2gcR2BeLMECLSfG359ehg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated from 2.5.0 to 2.5.1
  * Improved API response parsing to gracefully handle additional fields in responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->